### PR TITLE
Fix background variable on hover

### DIFF
--- a/src/source.css
+++ b/src/source.css
@@ -164,3 +164,6 @@
 .channel__972a0 .interactive_bf202d {
   background: transparent;
 }
+.voiceChannelHighlightBorder_c69b6d, .voiceChannelHighlightGlow_c69b6d {
+  display: none;
+}

--- a/src/source.css
+++ b/src/source.css
@@ -19,7 +19,7 @@
 }
 
 :root {
-  --indicator-hover: var(--background-modifier-hover);
+  --indicator-hover: var(--background-mod-subtle);
   --indicator-unread-border: hsla(var(--indicator-unread)/0.75);
   --indicator-unread-background: hsla(var(--indicator-unread)/0.05);
   --indicator-unread-hover-background: hsla(var(--indicator-unread)/0.10);


### PR DESCRIPTION
This Pull Request fixes the variable responsible for a light-gray background appearing once hovering over a channel, and also hides the overlapping green status bar to the side of an active voice channel in a server.